### PR TITLE
Core compatibility: replace StandaloneAuthClient with Yii2 BaseClient + auth()

### DIFF
--- a/authclient/JWT.php
+++ b/authclient/JWT.php
@@ -8,18 +8,17 @@
 
 namespace humhub\modules\sso\jwt\authclient;
 
-use humhub\modules\user\authclient\BaseClient;
 use humhub\modules\user\services\AuthClientUserService;
 use Yii;
-use humhub\modules\user\authclient\interfaces\StandaloneAuthClient;
 use humhub\modules\user\models\User;
 use Firebase\JWT\JWT as FirebaseJWT;
 use Firebase\JWT\Key as FirebaseJWTKey;
+use yii\authclient\BaseClient;
 
 /**
  * JWT Authclient
  */
-class JWT extends BaseClient implements StandaloneAuthClient
+class JWT extends BaseClient
 {
     /**
      * @var string url of the JWT provider
@@ -70,7 +69,7 @@ class JWT extends BaseClient implements StandaloneAuthClient
     /**
      * @inheritdoc
      */
-    public function authAction($authAction)
+    public function auth()
     {
         $token = Yii::$app->request->get('jwt');
 
@@ -92,9 +91,6 @@ class JWT extends BaseClient implements StandaloneAuthClient
 
         $this->setUserAttributes((array)$decodedJWT);
         $this->autoStoreAuthClient();
-
-
-        return $authAction->authSuccess($this);
     }
 
     /**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 
 - Enh: Use PHP CS Fixer
 - Fix #9: Adjust JWT client to use new JWT package version
+- Enh: Adapted to deprecation of `StandaloneAuthClient` interface and custom `AuthAction` (core: [humhub/humhub#8127](https://github.com/humhub/humhub/pull/8127))
+- Requires HumHub 1.19+ due to removal of `StandaloneAuthClient` and custom `AuthAction`
 
 1.1.3 (November 23, 2023)
 -------------------------

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
     ],
     "version": "1.1.4",
     "humhub": {
-        "minVersion": "1.18"
+        "minVersion": "1.19"
     },
     "homepage": "https://github.com/humhub/jwt-sso",
     "screenshots": []


### PR DESCRIPTION
## Summary

Adapts this module to the deprecation of `humhub\modules\user\authclient\interfaces\StandaloneAuthClient` and the custom `humhub\modules\user\authclient\AuthAction` in HumHub core.

The JWT client now extends `yii\authclient\BaseClient` directly and implements `auth()` instead of `authAction($authAction)`. Returning a `Response` from `auth()` redirects (broker URL or login page); returning `null` lets the standard `yii\authclient\AuthAction` trigger the success callback.

**Core PR:** https://github.com/humhub/humhub/pull/8127

## Changes

- `authclient/JWT.php`:
  - Extend `yii\authclient\BaseClient` instead of `humhub\modules\user\authclient\BaseClient`
  - Drop `implements StandaloneAuthClient`
  - Rename `authAction($authAction)` to `auth()`
  - Remove the trailing `return $authAction->authSuccess($this)` — the standard AuthAction handles the success callback
- `module.json`: bump `humhub.minVersion` from `1.18` to `1.19`
- `docs/CHANGELOG.md`: changelog entry

## module.json

- `minVersion` updated to `1.19`: yes — the deprecated interface and AuthAction are no longer present in core 1.19

## Testing

- [ ] Tested against HumHub 1.19+ (develop branch)
- [ ] No regressions in JWT login flow (token redirect, broker redirect, error redirect)